### PR TITLE
[Changmo][+] 조이스틱, 구명보트, 단속카메라, 섬 연결하기, 징검다리, 블록 이동하기

### DIFF
--- a/changmo/side/구명보트.py
+++ b/changmo/side/구명보트.py
@@ -1,0 +1,12 @@
+def solution(people, limit):
+    people.sort()
+
+    boat_for_two = 0
+    l, r = 0, len(people) - 1
+    while r > l:
+        if people[l] + people[r] <= limit:
+            l += 1
+            boat_for_two +=1
+        r -= 1
+
+    return len(people) - boat_for_two

--- a/changmo/side/단속카메라.py
+++ b/changmo/side/단속카메라.py
@@ -1,0 +1,14 @@
+ENTRANCE, EXIT = 0, 1
+def solution(routes):
+    routes.sort()
+        
+    answer = 1
+    camera = routes[0][EXIT]
+    for route in routes[1:]:
+        if route[ENTRANCE] > camera:
+            answer += 1
+            camera = route[EXIT]
+        elif route[EXIT] < camera:
+            camera = route[EXIT]
+
+    return answer

--- a/changmo/side/블록_이동하기.py
+++ b/changmo/side/블록_이동하기.py
@@ -1,0 +1,73 @@
+dr = [-1, 1, 0, 0]
+dc = [0, 0, -1, 1]
+ROW, COL = 0, 1
+def solution(board):
+    N = len(board)
+    visited = set()
+    
+    q = [ ((0, 0), (0, 1))]
+    visited.add( ((0, 0), (0, 1)) )
+    
+    time = 0
+    while q:
+        qs, q = q, []
+        
+        for left, right in qs:
+            left_r, left_c = left
+            right_r, right_c = right
+            
+            if (left_r, left_c) == (N - 1, N - 1) or (right_r, right_c) == (N - 1, N - 1):
+                return time
+
+            if left[ROW] == right[ROW]:
+                for x in range(4):
+                    new_left_r, new_left_c, new_right_r, new_right_c = left_r + dr[x], left_c + dc[x], right_r + dr[x], right_c + dc[x]
+                    if 0 <= new_left_r < N and 0 <= new_left_c < N and 0 <= new_right_r < N and 0 <= new_right_c < N and \
+                        not board[new_left_r][new_left_c] and not board[new_right_r][new_right_c] and ((new_left_r, new_left_c), (new_right_r, new_right_c)) not in visited:
+                        if x == 0:
+                            if ((left_r - 1, left_c + 1), (right_r, right_c)) not in visited:
+                                q.append( ((left_r - 1, left_c + 1), (right_r, right_c)) )
+                                visited.add( ((left_r - 1, left_c + 1), (right_r, right_c)) )
+
+                            if ((right_r - 1, right_c - 1), (left_r, left_c)) not in visited:
+                                q.append( ((right_r - 1, right_c - 1), (left_r, left_c)) )
+                                visited.add( ((right_r - 1, right_c - 1), (left_r, left_c)) )
+
+                        elif x == 1:
+                            if ((right_r, right_c), (left_r + 1, left_c + 1)) not in visited:
+                                q.append( ((right_r, right_c), (left_r + 1, left_c + 1)) )
+                                visited.add( ((right_r, right_c), (left_r + 1, left_c + 1)) )
+                                
+                            if ((left_r, left_c), (right_r + 1, right_c - 1)) not in visited:
+                                q.append( ((left_r, left_c), (right_r + 1, right_c - 1)) )
+                                visited.add( ((left_r, left_c), (right_r + 1, right_c - 1)) )
+
+                        q.append( ((new_left_r, new_left_c), (new_right_r, new_right_c)) )
+                        visited.add( ((new_left_r, new_left_c), (new_right_r, new_right_c)) )
+            else:
+                for x in range(4):
+                    new_left_r, new_left_c, new_right_r, new_right_c = left_r + dr[x], left_c + dc[x], right_r + dr[x], right_c + dc[x]
+                    if 0 <= new_left_r < N and 0 <= new_left_c < N and 0 <= new_right_r < N and 0 <= new_right_c < N and \
+                        not board[new_left_r][new_left_c] and not board[new_right_r][new_right_c] and ((new_left_r, new_left_c), (new_right_r, new_right_c)) not in visited:
+                        if x == 2:
+                            if ((left_r + 1, left_c - 1), (right_r, right_c)) not in visited:
+                                q.append( ((left_r + 1, left_c - 1), (right_r, right_c)) )
+                                visited.add( ((left_r + 1, left_c - 1), (right_r, right_c)) )
+                                
+                            if ((right_r - 1, right_c - 1), (left_r, left_c)) not in visited:
+                                q.append( ((right_r - 1, right_c - 1), (left_r, left_c)) )
+                                visited.add( ((right_r - 1, right_c - 1), (left_r, left_c)) )
+                                
+                        elif x == 3:
+                            if ((right_r, right_c), (left_r + 1, left_c + 1)) not in visited:
+                                q.append( ((right_r, right_c), (left_r + 1, left_c + 1)) )
+                                visited.add( ((right_r, right_c), (left_r + 1, left_c + 1)) )
+                                
+                            if ((left_r, left_c), (right_r - 1, right_c + 1)) not in visited:
+                                q.append( ((left_r, left_c), (right_r - 1, right_c + 1)) )
+                                visited.add( ((left_r, left_c), (right_r - 1, right_c + 1)) )
+                        
+                        q.append( ((new_left_r, new_left_c), (new_right_r, new_right_c)) )
+                        visited.add( ((new_left_r, new_left_c), (new_right_r, new_right_c)) )
+
+        time += 1

--- a/changmo/side/섬_연결하기.py
+++ b/changmo/side/섬_연결하기.py
@@ -1,0 +1,42 @@
+from collections import deque
+
+COST = 2
+def solution(n, costs):
+    def bfs(start):
+        nonlocal conn
+        
+        visited = [False]*n
+        visited[start] = True
+        
+        q = deque([start])
+        
+        while q:
+            a = q.popleft()
+            for b in adj[a]:
+                if not visited[b]:
+                    visited[b] = True
+                    q.append(b)
+        
+        conn = {i for i, flag in enumerate(visited) if flag}
+        
+        return sum(visited) == n
+
+
+    costs.sort(key=lambda x:x[COST])
+    
+    adj = [set() for _ in range(n)]
+    
+    answer = 0
+    conn = set()
+    
+    for f, t, c in costs:
+        if f in conn and t in conn:
+            continue
+
+        adj[f].add(t)
+        adj[t].add(f)
+
+        answer += c
+        
+        if bfs(f):
+            return answer

--- a/changmo/side/조이스틱.py
+++ b/changmo/side/조이스틱.py
@@ -1,0 +1,51 @@
+from string import ascii_uppercase as A_TO_Z
+
+UP = {alphabet: i for i, alphabet in enumerate(A_TO_Z)}
+DOWN = {alphabet: len(A_TO_Z) - i for i, alphabet in enumerate(A_TO_Z)}
+
+def solution(name):
+    v = [min(UP[alphabet], DOWN[alphabet]) for alphabet in name]
+    answer = sum(v)
+    
+    index = 0
+    if not v[0]:
+        l = r = index
+        cnt = 0
+        while True:
+            l = len(v) - 1 if l == 0 else l - 1
+            r = 0 if r == len(v) - 1 else r + 1
+                
+            cnt += 1
+            if cnt == len(v):
+                return 0
+            
+            if v[l]:
+                index = l
+                break
+                
+            if v[r]:
+                index = r
+                break
+
+    while True:
+        v[index] = 0
+        
+        l = r = index
+        cnt = 0
+        while True:
+            l = len(v) - 1 if l == 0 else l - 1
+            r = 0 if r == len(v) - 1 else r + 1
+                
+            cnt += 1
+            if cnt == len(v):
+                return answer
+            
+            if v[l]:
+                index = l
+                break
+                
+            if v[r]:
+                index = r
+                break
+
+        answer += cnt

--- a/changmo/side/징검다리.py
+++ b/changmo/side/징검다리.py
@@ -1,0 +1,26 @@
+def solution(distance, rocks, n):
+    target_interval_count = len(rocks) + 1 - n
+    rocks = [0] + sorted(rocks) + [distance]
+    
+    l, r = 1, distance
+    
+    while l <= r:
+        m = (l + r) // 2
+        
+        interval_distance = 0
+        interval_count = 0
+        for i in range(len(rocks) - 1):
+            interval_distance += rocks[i + 1] - rocks[i]
+            if interval_distance >= m:
+                interval_count += 1
+                interval_distance = 0
+        
+        if interval_distance:
+            interval_count -= 1
+        
+        if interval_count < target_interval_count:
+            r = m - 1
+        else:
+            l = m + 1
+    
+    return l - 1


### PR DESCRIPTION
## 조이스틱
[문제풀기](https://programmers.co.kr/learn/courses/30/lessons/42860)

문자를 어떻게든 만들어야 하기 때문에 문자를 만드는 최소한의 조작 횟수를 모두 합한 것을 전체 조작 횟수의 초기값으로 설정하였습니다.

문자를 바꾸기 위해 커서를 움직이는 조작을 더해야 하는데 현재 커서에서 바꿔야 하는 가장 가까운 위치의 문자로 커서를 옮기게 하였습니다.(이 부분에서 그리디 개념이 들어가는 것 같습니다)

추가적으로 문제에서 커서가 처음에 어디에 있는지 알려주지 않았기 때문에 최소한의 조작이 되도록 첫 커서 위치를 잡아주어야 했습니다.


## 구명보트
[문제풀기](https://programmers.co.kr/learn/courses/30/lessons/42885)

보트 하나에 최대한 limit을 맞춰서 태우는 경우를 찾는다.

무게를 오름차순으로 정렬하고 양쪽 끝에 인덱스(`l`, `r`)를 두고 두 합이 limit을 넘지 않을 때를 찾는다.


## 단속카메라
[문제풀기](https://programmers.co.kr/learn/courses/30/lessons/42884)

차량이 진출할 때를 기준으로 카메라를 설치해야 하는 문제


## 섬 연결하기
[문제풀기](https://programmers.co.kr/learn/courses/30/lessons/42861)

가격이 가장 낮은 순서부터 연결하고 이미 연결 된 섬을 다시 연결하지 않도록 하는 문제


## 징검다리

[문제풀기](https://programmers.co.kr/learn/courses/30/lessons/43236)

n 개의 바위를 제거한 후 각 바위 사이의 거리 중 최댓값을 찾는 문제

탐색할 공간의 최솟값을 1, 최댓값을 distance로 설정하여 이진 탐색을 진행한다.

n 개의 바위를 제거하면 항상 바위 사이의 개수가 `len(rocks) + 1 - n`으로 고정되는 것을 이용하여 바위 사이의 거리를 축적한 값(`interval_distance`)이 m 이상이 될 경우 바위 사이의 개수(`interval_count`)를 하나 늘려주는 방식을 사용했습니다. 바위를 다 순회하고도  축적한 값이 남았을 경우 바위 사이의 개수를 하나 빼주었습니다.


## 블록 이동하기

[문제풀기](https://programmers.co.kr/learn/courses/30/lessons/60063)

이렇게 풀지 말아야겠다고 느낀 문제...

`ㅡ`모양에서 위나 아래로 갈 수 있으면 회전이 가능하고
`ㅣ`모양에서 왼쪽이나 오른쪽으로 갈 수 있으면 회전이 가능한 이용하여 회전시에 따로 조건을 걸지 않았습니다.

---
DP와 그리디가 상당히 비슷한데 처음에 어떤 기준으로 데이터를 조작하고 시작하면 그리디를 사용할 가능성이 높고 그렇지 않은 경우 DP를 사용하는 것 같다.

이진 탐색은 정렬된 자료에서 어떤 값을 기준으로 그 값보다 작을 때 조건이 True(False)이고 그 값보다 크거나 같을 때 조건이 False(True)이면 사용하는 것 같다.

이진 탐색 문제를 풀 때는 아래의 코드를 적어놓고 시작하면 편한 것 같다.

```python
l, r = 최소, 최대

while l <= r:
    m = (l + r) // 2

    m과 관련시켜 조건을 만들기

    # 가능한 최소값 구할 때
    if 조건 >= m:
        r = m - 1
    else:
        l = m + 1

    return r - 1


    # 가능한 최대값 구할 때
    if 조건 < m:
        r = m - 1
    else:
        l = m + 1

    return l + 1
```