### PR TITLE
[Changmo] 단어변환, 전화번호 목록, 이중우선순위 큐, 저울, 도둑질, 외벽 점검

### DIFF
--- a/changmo/week4/단어변환.py
+++ b/changmo/week4/단어변환.py
@@ -1,0 +1,29 @@
+def solution(begin, target, words):
+    def check(word_a, word_b):
+        cnt = 0
+        for a, b in zip(word_a, word_b):
+            if a != b:
+                cnt += 1
+
+        if cnt == 1:
+            return True
+        return False
+
+
+    q = [begin]
+    visited = set([begin])
+
+    step = 0
+    while q:
+        qs, q = q, []
+        for search_target in qs:
+            for word in words:
+                if word not in visited and check(search_target, word):
+                    if word == target:
+                        return step + 1
+                    
+                    visited.add(word)
+                    q.append(word)
+        step += 1
+    
+    return 0

--- a/changmo/week4/도둑질.py
+++ b/changmo/week4/도둑질.py
@@ -1,0 +1,14 @@
+def solution(money):
+    N = len(money)
+
+    rob_0 = [0]*N
+    rob_0[0:2] = [money[0], money[0]]
+    for i in range(2, N - 1):
+        rob_0[i] = max(rob_0[i - 1], money[i] + rob_0[i - 2])
+    
+    skip_0 = [0]*N
+    skip_0[0:2] = [0, money[1]]
+    for i in range(2, N):
+        skip_0[i] = max(skip_0[i - 1], money[i] + skip_0[i - 2])
+    
+    return max(rob_0[-2], skip_0[-1])

--- a/changmo/week4/외벽_점검.py
+++ b/changmo/week4/외벽_점검.py
@@ -1,0 +1,28 @@
+from itertools import permutations
+
+def solution(n, weak, dist):
+    dist.sort(reverse=True)
+
+    W, D = len(weak), len(dist)
+    
+    for cnt in range(1, D + 1):
+        for order in permutations(dist, cnt):
+            for i in range(W):
+                target = weak[i:] + [n + w for w in weak[:i]]
+
+                if target[-1] - target[0] <= sum(order):
+                    return cnt
+
+                start = 0
+                for ord in order:
+                    inc = 0
+                    while True:
+                        if target[start + inc] - target[start] <= ord:
+                            inc += 1
+                            if start + inc == W:
+                                return cnt
+                        else:
+                            start += inc
+                            break
+
+    return -1

--- a/changmo/week4/이중우선순위큐.py
+++ b/changmo/week4/이중우선순위큐.py
@@ -1,0 +1,29 @@
+import heapq
+
+METHOD, NUM = 0, 1
+MIN, MAX = 0, 1
+def solution(operations):
+    double_priority_q = [[] for _ in range(2)]
+    
+    insert, delete = 0, 0
+    for op in operations:
+        op = op.split()
+        if op[METHOD] == 'I':
+            op[NUM] = int(op[NUM])
+            heapq.heappush(double_priority_q[MIN], op[NUM])
+            heapq.heappush(double_priority_q[MAX], -op[NUM])
+            insert += 1
+        elif op[NUM] == '1' and double_priority_q[MAX]:
+            heapq.heappop(double_priority_q[MAX])
+            delete += 1
+        elif op[NUM] == '-1' and double_priority_q[MIN]:
+            heapq.heappop(double_priority_q[MIN])
+            delete += 1
+
+        if insert == delete:
+            double_priority_q = [[] for _ in range(2)]
+
+    if insert == delete:
+        return [0, 0]
+    else:
+        return [-heapq.heappop(double_priority_q[MAX]), heapq.heappop(double_priority_q[MIN])]

--- a/changmo/week4/저울.py
+++ b/changmo/week4/저울.py
@@ -1,0 +1,10 @@
+def solution(weight):
+    weight.sort()
+    scale = 0
+    for w in weight:
+        if w > scale + 1:
+            break
+        
+        scale += w
+
+    return scale + 1

--- a/changmo/week4/전화번호_목록.py
+++ b/changmo/week4/전화번호_목록.py
@@ -1,0 +1,8 @@
+def solution(phone_book):
+    cache = set()
+    for phone in phone_book:
+        for cached_phone in cache:
+            if cached_phone == phone[:len(cached_phone)] or phone == cached_phone[:len(phone)]:
+                return False
+        cache.add(phone)
+    return True

--- a/changmo/week4/전화번호_목록.py
+++ b/changmo/week4/전화번호_목록.py
@@ -1,8 +1,7 @@
 def solution(phone_book):
-    cache = set()
+    phone_book = set(phone_book)
     for phone in phone_book:
-        for cached_phone in cache:
-            if cached_phone == phone[:len(cached_phone)] or phone == cached_phone[:len(phone)]:
+        for i in range(1, len(phone)):
+            if phone[:i] in phone_book:
                 return False
-        cache.add(phone)
     return True


### PR DESCRIPTION
## 단어변환

기본적인 BFS로직에 알파벳이 한 부분만 바뀌었는지 확인하여 진행하였습니다.


## 전화번호 목록

`phone_book`을 set 자료형으로 바꾸어 조사하였습니다.


## 이중우선순위 큐

두개의 리스트(min부분 max부분)를 사용하여 구현하였습니다.

이때 중요한 것은 insert할 때는 2곳 모두에 넣지만 삭제할 때는 한 곳에서만 빼기 때문에 insert와 delete를 각각 카운트해서 insert와 delete의 횟수가 같을 경우 모든 큐를 초기화 해야합니다.


## 저울

weight를 오름차순으로 정렬하고 추의 누적합(scale)을 0으로 초기화하였습니다.

weight를 하나씩 조사하는데 현재 scale보다 2 이상 큰 경우 scale + 1을 만들 수 없습니다.


## 도둑질

원형 리스트이기 때문에 첫 집을 털은 경우와 안 털은 경우로 나누어 생각해야 합니다.

`dp[i] = max(dp[i - 1], dp[i - 2] + money[i])`


## 외벽 점검

permutations을 이용하여 완전탐색 했습니다.